### PR TITLE
[FEAT] Add the parsing specify addresses function

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,48 @@ Content: ipfs://QmTeW79w7QQ6Npa3b1d5tANreCDxF2iDaAPsDvW6KtLmfB
 ✨  Done in 22.56s.
 ```
 
+Postscript: If you want to specify the eth or btc address of the token.eth domain, you can use eth + dot + domain or btc + dot + domain to resolve:
+
+```bash
+yarn start-goerli:client --registry 0x12315f08329E9727292b055e91A5b4878E264afF eth.token.eth
+yarn start-goerli:client --registry 0x12315f08329E9727292b055e91A5b4878E264afF btc.token.eth
+yarn start-goerli:client --registry 0x12315f08329E9727292b055e91A5b4878E264afF ltc.token.eth
+```
+
+You should see output similar to the following:
+
+```
+% yarn start-goerli:client --registry 0x12315f08329E9727292b055e91A5b4878E264afF eth.token.eth
+
+yarn run v1.22.19
+$ yarn workspace @ensdomains/offchain-resolver-client start-goerli --registry 0x12315f08329E9727292b055e91A5b4878E264afF eth.token.eth
+$ eval $(grep '^ALCHEMY_TOKEN' .env) && node dist/index.js --chainId 5 --chainName goerli --provider https://eth-goerli.alchemyapi.io/v2/${ALCHEMY_TOKEN} --registry 0x12315f08329E9727292b055e91A5b4878E264afF eth.token.eth
+Resolving token.eth domain...
+ETH address: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+        └─ decode to onchain hex: 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
+✨  Done in 10.53s.
+
+% yarn start-goerli:client --registry 0x12315f08329E9727292b055e91A5b4878E264afF btc.token.eth
+
+yarn run v1.22.19
+$ yarn workspace @ensdomains/offchain-resolver-client start-goerli --registry 0x12315f08329E9727292b055e91A5b4878E264afF btc.token.eth
+$ eval $(grep '^ALCHEMY_TOKEN' .env) && node dist/index.js --chainId 5 --chainName goerli --provider https://eth-goerli.alchemyapi.io/v2/${ALCHEMY_TOKEN} --registry 0x12315f08329E9727292b055e91A5b4878E264afF btc.token.eth
+Resolving token.eth domain...
+BTC address: 1Ei9UmLQv4o4UJTy5r5mnGFeC9auM3W5P1
+        └─ decode to onchain hex: 0x76a9149661c46c94700b2cc891109fffc3a49b26d1f78e88ac
+✨  Done in 10.27s.
+
+% yarn start-goerli:client --registry 0x12315f08329E9727292b055e91A5b4878E264afF ltc.token.eth
+
+yarn run v1.22.19
+$ yarn workspace @ensdomains/offchain-resolver-client start-goerli --registry 0x12315f08329E9727292b055e91A5b4878E264afF ltc.token.eth
+$ eval $(grep '^ALCHEMY_TOKEN' .env) && node dist/index.js --chainId 5 --chainName goerli --provider https://eth-goerli.alchemyapi.io/v2/${ALCHEMY_TOKEN} --registry 0x12315f08329E9727292b055e91A5b4878E264afF ltc.token.eth
+Resolving token.eth domain...
+LTC address: Ld797g7vcD34F4m3pCR5fb1Z98yEswMLGX
+        └─ decode to onchain hex: 0x76a914c428696e02ed7f5b41a9f180367bebb2b408422088ac
+✨  Done in 9.96s.
+```
+
 Check these addresses against the gateway's `token.eth.json` and you will see that they match.
 
 ## Real-world usage

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -94,7 +94,7 @@ async function resolveGivenCoin(domain: string) {
   const resolver = await provider.getResolver(name);
 
   if (!resolver) {
-    console.log(`[Error] No resolver contract or gateway server found`);
+    console.log(`[Error] No resolver contract found`);
     process.exit(0);
   }
 
@@ -114,7 +114,7 @@ async function resolveAllData(domain: string) {
   const resolver = await provider.getResolver(domain);
 
   if (!resolver) {
-    console.log(`[Error] No resolver contract or gateway server found`);
+    console.log(`[Error] No resolver contract found`);
     process.exit(0);
   }
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -28,7 +28,7 @@ const provider = new ethers.providers.JsonRpcProvider(options.provider, {
     // Coin resolution is successful, print the specified coin address
     resolveGivenCoin(name);
   } else {
-    // Coin resolution is fails, print the all info
+    // Coin resolution fails, print all info
     resolveAllData(name);
   }
 })();
@@ -39,9 +39,9 @@ function addressToOnchainHex(address: string, coinType: string): string {
   return `0x${onchain.toString('hex')}`;
 }
 
-// Judge the domain contains coin name
+// Determine if the first name in the domain is a name of a coin
 function isGivenCoin(domain: string): boolean {
-  // Try to get the coin name from first element of domain name to resolve
+  // Try to get the first name in the domain
   const domainArray = domain.split('.');
   if (domainArray.length <= 1) {
     console.log(`[Error] Domain must have at least one dot "."`);
@@ -51,13 +51,13 @@ function isGivenCoin(domain: string): boolean {
   return isCoin(coinName);
 }
 
-// Judge the string is coin name
+// Determine if the name is name of a coin
 function isCoin(name: string): boolean {
   const coinType = getCoinType(name);
   return coinType === null ? false : true;
 }
 
-// Transfer coin name to coin type number
+// Get coin type from the name
 // Coin type reference: https://github.com/satoshilabs/slips/blob/master/slip-0044.md#registered-coin-types
 function getCoinType(coinName: string): number | null {
   let coinType: number | null = null;
@@ -86,8 +86,8 @@ async function resolveGivenCoin(domain: string) {
   const coinType = getCoinType(coinName)!;
   const coinNameToUpper = coinName.toUpperCase();
 
-  // Change name to the real domain.
-  // E.g.: btc.token.eth -> real domain = token.eth
+  // Remove coin name from domain
+  // E.g.: btc.token.eth -> token.eth
   const name = domainArray.slice(1, domainArray.length).join('.');
 
   console.log(`Resolving ${name} domain...`);


### PR DESCRIPTION
### New feature
Add the use of eth + dot + domain or btc + dot + domain
parsing specify the eth or btc address of the token.eth domain.

### How to verify?
Please read the new [Readme.md](https://github.com/NIC619/offchain-resolver/blob/IRARA/resolve_only_btc_or_eth_addresses/README.md) file.

Thanks!